### PR TITLE
Provider-Address Hot Fix

### DIFF
--- a/src/main/java/com/example/cs4500_sp19_random1/models/Provider.java
+++ b/src/main/java/com/example/cs4500_sp19_random1/models/Provider.java
@@ -23,13 +23,13 @@ public class Provider {
     private boolean backgroundChecked;
     private String introduction;
 
+    @Embedded
     private Address businessAddress;
-    private String zipCode = businessAddress.getZipCode();
     private String businessEmail;
     private int yearFounded;
     private boolean creditCard;
     private boolean cash;
-    private boolean check;
+    private boolean paperCheck; // SQL doesn't like "check"
     private boolean venmo;
     private boolean paypal;
     private boolean square;
@@ -66,11 +66,11 @@ public class Provider {
     }
 
     public boolean acceptsCheck() {
-        return check;
+        return paperCheck;
     }
 
     public void setCheck(boolean check) {
-        this.check = check;
+        this.paperCheck = check;
     }
 
     public boolean acceptsVenmo() {

--- a/src/main/java/com/example/cs4500_sp19_random1/repositories/ServiceProviderRepository.java
+++ b/src/main/java/com/example/cs4500_sp19_random1/repositories/ServiceProviderRepository.java
@@ -17,10 +17,8 @@ public interface ServiceProviderRepository extends CrudRepository<ServiceProvide
   @Query(value = "SELECT provider FROM ServiceProvider provider WHERE provider.name=:username")
   public ServiceProvider findByServiceProvidername(@Param("username") String username);
 
-  @Query(value = "SELECT provider FROM ServiceProvider provider WHERE (:provider is null or provider.name LIKE :provider%) AND " +
-          "(:zipCode is null or provider.zipCode=:zipCode)")
-  public List<ServiceProvider> filterAllServiceProviders(@Param("provider") String provider,
-                                                         @Param("zipCode") String zipCode);
+  @Query(value = "SELECT provider FROM Provider provider WHERE (:provider is null or provider.name LIKE :provider%)")
+  public List<ServiceProvider> filterAllServiceProviders(@Param("provider") String provider);
 
   List<ServiceProvider> findAllByServiceId(Integer id);
 }

--- a/src/main/java/com/example/cs4500_sp19_random1/repositories/ServiceProviderRepository.java
+++ b/src/main/java/com/example/cs4500_sp19_random1/repositories/ServiceProviderRepository.java
@@ -17,7 +17,7 @@ public interface ServiceProviderRepository extends CrudRepository<ServiceProvide
   @Query(value = "SELECT provider FROM ServiceProvider provider WHERE provider.name=:username")
   public ServiceProvider findByServiceProvidername(@Param("username") String username);
 
-  @Query(value = "SELECT provider FROM Provider provider WHERE (:provider is null or provider.name LIKE :provider%)")
+  @Query(value = "SELECT provider FROM ServiceProvider provider WHERE (:provider is null or provider.name LIKE :provider%)")
   public List<ServiceProvider> filterAllServiceProviders(@Param("provider") String provider);
 
   List<ServiceProvider> findAllByServiceId(Integer id);

--- a/src/main/java/com/example/cs4500_sp19_random1/services/ServiceProviderService.java
+++ b/src/main/java/com/example/cs4500_sp19_random1/services/ServiceProviderService.java
@@ -41,6 +41,12 @@ public class ServiceProviderService {
     if(zipCode == "") {
       zipCode = null;
     }
-    return serviceProviderRepository.filterAllServiceProviders(provider, zipCode);
+    List<ServiceProvider> serviceProviders = serviceProviderRepository.filterAllServiceProviders(provider);
+    /*
+      TODO: Add zip code filtering here.
+      The math will be easier to do in Java once we have the provider list,
+      rather than trying to mess around with the SQL.
+     */
+    return serviceProviders;
   }
 }

--- a/src/main/java/com/example/cs4500_sp19_random1/util/Address.java
+++ b/src/main/java/com/example/cs4500_sp19_random1/util/Address.java
@@ -16,6 +16,13 @@ public class Address {
     this.zipCode = zipCode;
   }
 
+  public Address() {
+    this.street = "";
+    this.city = "";
+    this.state = "";
+    this.zipCode = "";
+  }
+
   public String getStreet() {
     return street;
   }

--- a/src/main/java/com/example/cs4500_sp19_random1/util/Address.java
+++ b/src/main/java/com/example/cs4500_sp19_random1/util/Address.java
@@ -1,5 +1,8 @@
 package com.example.cs4500_sp19_random1.util;
 
+import javax.persistence.Embeddable;
+
+@Embeddable
 public class Address {
   private String street;
   private String city;

--- a/src/test/java/com/example/cs4500_sp19_random1/ServiceProviderServiceTest.java
+++ b/src/test/java/com/example/cs4500_sp19_random1/ServiceProviderServiceTest.java
@@ -57,7 +57,7 @@ public class ServiceProviderServiceTest {
             thenReturn(serviceProvider);
     Mockito.when(serviceProviderRepository.findByServiceProvidername("TestProvider")).
             thenReturn(serviceProvider);
-    Mockito.when(serviceProviderRepository.filterAllServiceProviders("TestProvider", "02120"))
+    Mockito.when(serviceProviderRepository.filterAllServiceProviders("TestProvider"))
             .thenReturn(oneProvider);
 
   }


### PR DESCRIPTION
PR #50 broke the build as JPA couldn't recognize the Address type and map it to a SQL type. I made a few changes to fix this:

- Added Address as an Embedded type. This maps all the fields from the Address class into the Provider table. 
- Fixed an issue with "check" column in provider. It needed to be changed to something other than "check" for the SQL syntax to work. 
- Starting the process of moving the zip code filtering out of the ServiceProviderRepository and into the service. Another PR will follow this one to implement that.
- Modified the test to reflect the change.