### PR TITLE
Validate UserTest and ServiceCategoryTest

### DIFF
--- a/src/test/java/com/example/cs4500_sp19_random1/ServiceCategoryTest.java
+++ b/src/test/java/com/example/cs4500_sp19_random1/ServiceCategoryTest.java
@@ -29,7 +29,7 @@ import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 
-/*
+
 @RunWith(SpringRunner.class)
 @WebMvcTest(ServiceCategoryService.class)
 public class ServiceCategoryTest {
@@ -106,5 +106,3 @@ public class ServiceCategoryTest {
                         containsInAnyOrder("Pet Services","Health Services")));;
     }
 }
-
-*/

--- a/src/test/java/com/example/cs4500_sp19_random1/UserTest.java
+++ b/src/test/java/com/example/cs4500_sp19_random1/UserTest.java
@@ -21,7 +21,7 @@ import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 
-/*
+
 @RunWith(SpringRunner.class)
 @WebMvcTest(UserService.class)
 public class UserTest {
@@ -84,4 +84,3 @@ public class UserTest {
             .andExpect(status().isOk());
   }
 }
-*/


### PR DESCRIPTION
A few days ago a set of tests were commented out due to failures we were seeing on master. These tests were a part of that set, but after some investigation I have determined these tests actually just work. I was really hoping to get the service category and service integration tests back as a part of this PR as well (addressing https://jira.ccs.neu.edu/browse/SD15-304), but for that I see only two options:

* A significant overhaul to how those tests are being run
or
* Paying a monthly cost to upgrade our max_user_connections for our one user

Obviously the latter is less than desirable for a term project coming to an end in approximately 24 hours. But I also don't think the first option is a valuable effort -- we have established that these tests are functional in isolation (thus verifying that what is being tested certainly works) 

@texzone please review